### PR TITLE
Update documentation for injecting anomalies if user not using rke2 cluster

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -25,7 +25,18 @@ Make sure to be in the Global Tenant mode if you are not already. Click on Dashb
 
 To view the anomaly detection press 'Enter' in the console window running the script to inject an anomaly.
 
-You can also choose to inject different anomalies such as creating pods which are unschedulable, have nonexistent images and exiting with non-zero exit codes.
+
+You can also choose to inject different anomalies such as creating pods which are unschedulable, have nonexistent images and exiting with non-zero exit codes. 
+
+Note: If you are not using the quickstart script, make sure to set the KUBECONFIG environment variable like
+```
+export KUBECONFIG=[PATH_TO_KUBECONFIG_FILE]
+```
+and your Kubectl path like
+```
+export PATH=[PATH_TO_KUBECTL_BINARY]
+```
+Then, you can inject anomalies into your cluster with this command:
 ```
 sh <(curl -sfL https://raw.githubusercontent.com/rancher/opni-docs/main/quickstart_files/errors_injection.sh)
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,20 +21,19 @@ Open the following address in a browser
 [IPV4_ADDRESS]:[NODE_PORT]
 ``` 
 The default username and password is admin/admin
-Make sure to be in the Global Tenant mode if you are not already. Click on Dashboard, Opni Logs Dashboard.
+You must be in the Global Tenant mode if you are not already. Click on Dashboard, Opni Logs Dashboard.
 
 To view the anomaly detection press 'Enter' in the console window running the script to inject an anomaly.
 
 
-You can also choose to inject different anomalies such as creating pods which are unschedulable, have nonexistent images and exiting with non-zero exit codes. 
-
+Using the provided script, you can inject sample anomalies into your cluster. The script can create pods which are unschedulable, have nonexistent images, or exit with non-zero exit codes.
 Note: If you are not using the quickstart script, make sure to set the KUBECONFIG environment variable like
 ```
 export KUBECONFIG=[PATH_TO_KUBECONFIG_FILE]
 ```
 and your Kubectl path like
 ```
-export PATH=[PATH_TO_KUBECTL_BINARY]
+export PATH=$PATH:[PATH_TO_KUBECTL_BINARY]
 ```
 Then, you can inject anomalies into your cluster with this command:
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,7 @@ To view the anomaly detection press 'Enter' in the console window running the sc
 
 
 Using the provided script, you can inject sample anomalies into your cluster. The script can create pods which are unschedulable, have nonexistent images, or exit with non-zero exit codes.
-Note: If you are not using the quickstart script, make sure to set the KUBECONFIG environment variable like
+Note: If you are not using the quickstart script, you must set the KUBECONFIG environment variable like
 ```
 export KUBECONFIG=[PATH_TO_KUBECONFIG_FILE]
 ```


### PR DESCRIPTION
Updated documentation about steps user may need to take if they are not using an RKE2 cluster from the quickstart. 