### PR TITLE
Update shell script to only inject pod exiting with non zero exit code and non existent image errors

### DIFF
--- a/quickstart_files/errors_injection.sh
+++ b/quickstart_files/errors_injection.sh
@@ -1,33 +1,5 @@
 #!/bin/sh
 export KUBECONFIG="${KUBECONFIG:-/etc/rancher/rke2/rke2.yaml}" PATH="${PATH:+${PATH}:}/var/lib/rancher/rke2/bin/"
-inject_unschedulable_pods_anomaly() {
-    cat <<EOF | kubectl apply -f -
-    apiVersion: batch/v1
-    kind: Job
-    metadata:
-      name: test-job-unschedulable
-      labels:
-        is-opni-demo: "true"
-    spec:
-      completions: 10
-      parallelism: 10
-      template:
-        spec:
-          containers:
-            - name: test
-              image: busybox
-              command:
-              - /bin/ls
-          affinity:
-            nodeAffinity:
-              requiredDuringSchedulingIgnoredDuringExecution:
-                nodeSelectorTerms:
-                - matchExpressions:
-                  - key: nonexistent
-                    operator: Exists
-          restartPolicy: Never
-EOF
-}
 
 inject_nonexistent_image_pods_anomaly() {
     cat <<EOF | kubectl apply -f -
@@ -82,19 +54,15 @@ get_user_anomaly_input() {
   while true
   do
   	echo "Possible anomalies to inject"
-  	echo "1: Create 10 unschedulable pods."
-  	echo "2: Create 10 pods with nonexistent images."
-  	echo "3: Create 10 pods that will exit with non-zero exit codes."
+  	echo "1: Create 10 pods with nonexistent images."
+  	echo "2: Create 10 pods that will exit with non-zero exit codes."
     echo "u: Undo anomalies injected into cluster."
     echo "q: Exit this script."
   	read -p "Select the action you would like to perform: " anomaly
   	if [ "$anomaly" = '1' ]; then
-  		echo "Injecting the fault to create 10 unschedulable pods."
-  		inject_unschedulable_pods_anomaly
-  	elif [ "$anomaly" = '2' ]; then
   		echo "Injecting the fault to create 10 pods with nonexistent images."
   		inject_nonexistent_image_pods_anomaly
-  	elif [ "$anomaly" = '3' ]; then
+  	elif [ "$anomaly" = '2' ]; then
   		echo "Injecting the fault to create 10 pods that will exit with non-zero exit codes."
   		inject_nonzero_exit_code_pods_anomaly
     elif [ "$anomaly" = 'u' ]; then


### PR DESCRIPTION
Remove the pod can't be scheduled error injection from the shell script and update the menu options accordingly.