### PR TITLE
Remove stray quotation mark

### DIFF
--- a/docs/deployment/advanced.md
+++ b/docs/deployment/advanced.md
@@ -22,7 +22,7 @@ $ kubectl create -k config/default
 ```
 ### Wait for the operator to be ready
 ```
-$ kubectl wait --timeout=300s --for=condition=available deploy/opni-controller-manager -n opni-system`
+$ kubectl wait --timeout=300s --for=condition=available deploy/opni-controller-manager -n opni-system
 ```
 ### Configure and install Opni components
 


### PR DESCRIPTION
From the advanced installation guide, there is a stray quotation mark present when copying the command. 