### PR TITLE
Missing units in the sample cluster yaml

### DIFF
--- a/docs/logging/logging.md
+++ b/docs/logging/logging.md
@@ -45,7 +45,7 @@ spec:
   nodePools:
   - component: master
     replicas: 3
-    diskSize: 32
+    diskSize: 32Gi
     resources:
       requests:
         cpu: 500m
@@ -58,7 +58,7 @@ spec:
       emptyDir: {}
   - component: nodes
     replicas: 2
-    diskSize: 32
+    diskSize: 32Gi
     resources:
       requests:
         cpu: 500m


### PR DESCRIPTION
When following the setup process I received this error:
`The OpenSearchCluster "opni" is invalid: spec.nodePools.diskSize: Invalid value: "integer": spec.nodePools.diskSize in body must be of type string: "integer"`

I figure we wanted Gi as the units but I can amend if needed.